### PR TITLE
Add eslint to lint-staged

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,26 +1,27 @@
 {
-    "env": {
-        "browser": true,
-        "es2021": true
-    },
-    "extends": [
-        "eslint:recommended",
-        "plugin:react/recommended",
-        "plugin:@typescript-eslint/recommended",
-        "prettier"
-    ],
-    "overrides": [
-    ],
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-        "ecmaVersion": "latest",
-        "sourceType": "module"
-    },
-    "plugins": [
-        "react",
-        "@typescript-eslint"
-    ],
-    "rules": {
-        "react/react-in-jsx-scope": "off"
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "overrides": [],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": ["react", "@typescript-eslint"],
+  "rules": {
+    "react/react-in-jsx-scope": "off"
+  },
+  "settings": {
+    "react": {
+      "version": "detect"
     }
+  }
 }

--- a/env.d.ts
+++ b/env.d.ts
@@ -1,0 +1,3 @@
+declare module "react-native-dotenv" {
+  export const TILE_URL_TEMPLATE: string;
+}

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "private": true,
   "lint-staged": {
     "*.{ts,tsx}": [
+      "eslint --fix --max-warnings=0",
       "prettier --write"
     ]
   }

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -6,9 +6,7 @@ import { useRecoilState } from "recoil";
 import { LocationObject, LocationObjectCoords } from "expo-location";
 import { distance, locationSetup } from "../location/location";
 import { currentLocation } from "../recoil/atom";
-
-// @ts-ignore
-import { TILE_URL_TEMPLATE } from "@env";
+import { TILE_URL_TEMPLATE } from "react-native-dotenv";
 
 const DIGS: LocationObjectCoords = {
   latitude: 63.43133846620186,
@@ -23,7 +21,7 @@ const DIGS: LocationObjectCoords = {
 const Map = () => {
   const MIN_ZOOM_LEVEL = 17;
   const MAX_ZOOM_LEVEL = 21;
-  const [location, setLocation] = useRecoilState(currentLocation);
+  const [location, setLocation] = useRecoilState(currentLocation); // eslint-disable-line @typescript-eslint/no-unused-vars
 
   const onPositionChange = (new_location: LocationObject) => {
     setLocation(new_location);


### PR DESCRIPTION
Closes #42 

`eslint` is now called inside `lint-staged` in the pre-commit hook. Currently using `max-warnings=0` as a strict starting point. Might change this in the future.