### PR TITLE
Unmount when not Bagscreen deselected

### DIFF
--- a/src/screens/MainScreen.tsx
+++ b/src/screens/MainScreen.tsx
@@ -73,6 +73,7 @@ const MainScreen = () => {
           tabBarIcon: ({ color, size }) => (
             <FontAwesomeIcon icon={faBriefcase} color={color} size={size} />
           ),
+          unmountOnBlur: true,
         }}
       />
       <Tab.Screen


### PR DESCRIPTION
Problem: When we upon up the BagScreen and switch to another tab, the TabScreen is not unmounted. This can result in that the BagScreen does not show updated list of items if a user were to scan a qr code (and the bagscreen was already mounted before scanning qr). Therefore we want to unmount the BagScreen when we select another Tab